### PR TITLE
Use --depth=1 option during git clone when building from source

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ See the [releases page](https://github.com/reemus-dev/gitnr/releases) to downloa
 ### From Source
 
 ```sh
-git clone github.com/reemus-dev/gitnr
+git clone --depth=1 github.com/reemus-dev/gitnr
 cd gitnr
 cargo install --path .
 ```


### PR DESCRIPTION
Cloning with commit history doesn't make sense.