### PR TITLE
docs: add homebrew installation and reorganize installation section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ gitnr search
     - [Cargo Binstall](#cargo-binstall)
     - [Binary Download](#binary-download)
     - [NetBSD](#NetBSD)
+    - [Homebrew](#homebrew)
     - [From Source](#from-source)
 - [Usage](#usage)
     - [Create](#create)
@@ -90,6 +91,13 @@ See the [releases page](https://github.com/reemus-dev/gitnr/releases) to downloa
 On NetBSD a pre-compiled binary is available from the official repositories. To install it, simply run:
 ```sh
 pkgin install gitnr
+```
+
+### Homebrew
+
+You can also install the latest version using Homebrew:
+```sh
+brew install gitnr
 ```
 
 ### From Source

--- a/readme.md
+++ b/readme.md
@@ -21,14 +21,17 @@ gitnr search
 ## Table of Contents
 
 - [Installation](#install--update)
-    - [Linux & Mac](#linux--mac)
-    - [Windows](#windows)
-    - [Cargo](#cargo)
-    - [Cargo Binstall](#cargo-binstall)
-    - [Binary Download](#binary-download)
-    - [NetBSD](#NetBSD)
-    - [Homebrew](#homebrew)
-    - [From Source](#from-source)
+    - [Package Managers](#package-managers)
+        - [Homebrew (macOS / Linux)](#homebrew-macos--linux)
+        - [Cargo](#cargo)
+        - [Cargo Binstall](#cargo-binstall)
+        - [NetBSD](#netbsd)
+    - [Install Scripts](#install-scripts)
+        - [Linux & macOS](#linux--macos)
+        - [Windows](#windows)
+    - [Manual Install](#manual-install)
+        - [Binary Download](#binary-download)
+        - [From Source](#from-source)
 - [Usage](#usage)
     - [Create](#create)
     - [Search](#search)
@@ -37,7 +40,42 @@ gitnr search
 
 ## Install & Update
 
-### Linux & Mac
+### Package Managers
+
+#### Homebrew (macOS / Linux)
+
+Install the latest version using Homebrew with the command below.
+
+```sh
+brew install gitnr
+```
+
+#### Cargo
+
+Install and compile the latest version from crates.io with the command below.
+
+```sh
+cargo install gitnr
+```
+
+#### Cargo Binstall
+
+Install the binary directly using `cargo-binstall`.
+
+```sh
+cargo-binstall gitnr
+```
+
+#### NetBSD
+
+On NetBSD a pre-compiled binary is available from the official repositories. To install it, simply run:
+```sh
+pkgin install gitnr
+```
+
+### Install Scripts
+
+#### Linux & macOS
 
 Run any of the commands below in your terminal to get the latest version of `gitnr`.
 
@@ -58,7 +96,7 @@ _On Linux this defaults to `$HOME/.local/bin` and on macOS to `$HOME/bin`. The s
 curl -s https://raw.githubusercontent.com/reemus-dev/gitnr/main/scripts/install.sh | bash -s -- -d <dir>
 ```
 
-### Windows
+#### Windows
 
 Run the command below in a PowerShell terminal to install the latest version of `gitnr`.
 
@@ -66,41 +104,13 @@ Run the command below in a PowerShell terminal to install the latest version of 
 Set-ExecutionPolicy Unrestricted -Scope Process; iex (iwr "https://raw.githubusercontent.com/reemus-dev/gitnr/main/scripts/install.ps1").Content
 ```
 
-### Cargo
+### Manual Install
 
-Install and compile the latest version from crates.io with the command below.
-
-```sh
-cargo install gitnr
-```
-
-### Cargo Binstall
-
-Install the binary directly using `cargo-binstall`.
-
-```sh
-cargo-binstall gitnr
-```
-
-### Binary Download
+#### Binary Download
 
 See the [releases page](https://github.com/reemus-dev/gitnr/releases) to download a binary and then add it to a directory in your system path.
 
-### NetBSD
-
-On NetBSD a pre-compiled binary is available from the official repositories. To install it, simply run:
-```sh
-pkgin install gitnr
-```
-
-### Homebrew
-
-You can also install the latest version using Homebrew:
-```sh
-brew install gitnr
-```
-
-### From Source
+#### From Source
 
 ```sh
 git clone --depth=1 github.com/reemus-dev/gitnr


### PR DESCRIPTION
1. Adds installation instructions for Homebrew, which is now possible via [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/249335).
2. Reorganizes the installation into sections "Package Managers", "Install Scripts", and "Manual Install".

Resolves #16 